### PR TITLE
Exporting for commonjs packge loaders (node and browserify)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/cassis.js
+++ b/cassis.js
@@ -1468,7 +1468,11 @@ function tw_url_to_username($u) {
   return $u[3];
 }
 
-
+// CommonJS (node, browserify, npm) Exports
+if (js() && typeof exports !== 'undefined' && 
+    typeof module !== 'undefined' && module.exports) {
+  exports.auto_link = auto_link;
+}
 
 // ===================================================================
 // end CASSIS v0.1, cassis.js

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "cassis",
+  "version": "0.1.0",
+  "description": "",
+  "main": "cassis.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tantek/cassis.git"
+  },
+  "keywords": [
+    "functional programming",
+    "math",
+    "datetime computations",
+    "string processing",
+    "parsing",
+    "form validation"
+  ],
+  "author": {
+    "name" : "Tantek Çelik",
+    "url" : "http://tantek.com/"
+  },
+  "license": "CC BY-SA 3.0",
+  "bugs": {
+    "url": "https://github.com/tantek/cassis/issues"
+  },
+  "homepage": "http://tantek.pbworks.com/w/page/19402872/CassisProject"
+}

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "form validation"
   ],
   "author": {
-    "name" : "Tantek Çelik",
-    "url" : "http://tantek.com/"
+    "name": "Tantek Çelik",
+    "url": "http://tantek.com/"
   },
   "license": "CC BY-SA 3.0",
   "bugs": {


### PR DESCRIPTION
The Package.json is used for publishing on [npm](https://www.npmjs.com/).  These are the basic field from running `npm init`.

As for function exporting, I only exported `auto_link` to get feedback on PHP compatibility.  I put it all the way at the bottom, but could but it right next to the exported function, or even inline it with the declaration:
```js
exports.auto_link = function auto_link() {
  //...
}
// or
function auto_link { 
  //...
}
exports.auto_link = auto_link
```

This enables:
```sh
var cassis = require('cassis')
var linked = cassis.auto_link(words)
```
for node and browserify once cassis is installed into node_modules.