### PR TITLE
add circle ci support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Circle CI](https://circleci.com/gh/bear/cassis.svg?style=shield)](https://circleci.com/gh/tantek/cassis)
+
 cassis.js
 =========
 

--- a/circle.yml
+++ b/circle.yml
@@ -7,4 +7,4 @@ test:
     - phpcs --standard=PSR2
     - mkdir -p $CIRCLE_TEST_REPORTS/phpunit
     - phpunit --log-junit $CIRCLE_TEST_REPORTS/phpunit php-tests
-    - node test
+    - npm test

--- a/circle.yml
+++ b/circle.yml
@@ -4,5 +4,6 @@ machine:
 
 test:
   override:
-    - phpunit.phar
+    - mkdir -p $CIRCLE_TEST_REPORTS/phpunit
+    - phpunit --log-junit $CIRCLE_TEST_REPORTS/phpunit php-tests
     - tape js-tests/*.js | tap-spec

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
 test:
   pre:
     - mkdir -p $CIRCLE_TEST_REPORTS/phpunit
+    - npm i -g eslint
   override:
     - phpcs --standard=PSR2 cassis.php
     - phpunit --log-junit $CIRCLE_TEST_REPORTS/phpunit php-tests

--- a/circle.yml
+++ b/circle.yml
@@ -12,3 +12,4 @@ test:
     - phpcs --standard=PSR2 cassis.php
     - phpunit --log-junit $CIRCLE_TEST_REPORTS/phpunit php-tests
     - eslint cassis.js
+    - npm test

--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,10 @@ machine:
     version: 5.5.11
 
 test:
+  pre:
+    - mkdir -p $CIRCLE_TEST_REPORTS/phpunit
   override:
     - phpcs --standard=PSR2 cassis.php
-    - mkdir -p $CIRCLE_TEST_REPORTS/phpunit
     - phpunit --log-junit $CIRCLE_TEST_REPORTS/phpunit php-tests
+    - eslint cassis.js
     - npm test

--- a/circle.yml
+++ b/circle.yml
@@ -2,12 +2,13 @@ machine:
   php:
     version: 5.5.11
 
-test:
+dependencies:
   pre:
     - mkdir -p $CIRCLE_TEST_REPORTS/phpunit
     - npm i -g eslint
+
+test:
   override:
     - phpcs --standard=PSR2 cassis.php
     - phpunit --log-junit $CIRCLE_TEST_REPORTS/phpunit php-tests
     - eslint cassis.js
-    - npm test

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 test:
   override:
-    - phpcs --standard=PSR2
+    - phpcs --standard=PSR2 cassis.php
     - mkdir -p $CIRCLE_TEST_REPORTS/phpunit
     - phpunit --log-junit $CIRCLE_TEST_REPORTS/phpunit php-tests
     - npm test

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,8 @@
+machine:
+  php:
+    version: 5.5.11
+
+test:
+  override:
+    - phpunit.phar
+    - tape js-tests/*.js | tap-spec

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,7 @@ machine:
 
 test:
   override:
+    - phpcs --standard=PSR2
     - mkdir -p $CIRCLE_TEST_REPORTS/phpunit
     - phpunit --log-junit $CIRCLE_TEST_REPORTS/phpunit php-tests
-    - tape js-tests/*.js | tap-spec
+    - node test


### PR DESCRIPTION
This configuration currently runs:
- phpcs --standard=PSR2 cassis.php
- phpunit --log-junit $CIRCLE_TEST_REPORTS/phpunit php-tests
- eslint cassis.js
- npm test

Note - I am _not_ a JS or PHP coder so I have used the default configurations for both the PHP and JS linters
