### PR TITLE
Simplify JS testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,5 @@ $ phpunit.phar
 To run the JS tests:
 
 ```
-$ tape js-tests/*.js | tap-spec
-```
-
-or if you don't have tape and tap-spec installed globally, then
-
-```
-$ ./node_modules/tape/bin/tape js-tests/*.js | ./node_modules/tap-spec/bin/cmd.js
+$ npm test
 ```


### PR DESCRIPTION
When executing scripts, npm adds `./node_modules/.bin` to $PATH. That
means that the user doesn't have to worry about having `tape` or
`tap-spec` installed globally.

Also, this means that if the user has an incompatible version of these
programs installed globally, things won't blow up.