### PR TITLE
Add Composer post-install script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,10 @@
 	"name": "tantek/cassis",
 	"autoload": {
 		"files": ["cassis.php"]
+	},
+	"scripts": {
+		"post-update-cmd": [
+			"@php post-process.php"
+		]
 	}
 }


### PR DESCRIPTION
This will run `post-process.php` after someone runs `composer install` on this package. This should ensure that cassis.php is regenerated and does not cause errors under PHP8.

Note: Event `post-update-cmd` is used because this project does not have a lock file currently. The post-update event fires on `composer update` OR `composer install` when there is no lock file.

https://getcomposer.org/doc/articles/scripts.md#event-names